### PR TITLE
Handling of facts->version for QFX5200

### DIFF
--- a/lib/junos-ez/facts/version.rb
+++ b/lib/junos-ez/facts/version.rb
@@ -34,6 +34,7 @@ Junos::Ez::Facts::Keeper.define( :version ) do |ndev, facts|
     unless master_id.nil?
       facts[:version] = 
         facts[("version_" + "RE" + master_id).to_sym] || 
+        facts[("version_" + "LOCALRE").to_sym] ||
         facts[('version_' + "FPC" + master_id).to_sym]
     end
   else


### PR DESCRIPTION
Copying this to handle version for QFX5200 vs 5100:

https://github.com/Juniper/ruby-junos-ez-stdlib/blob/834a9ae41c8fbd34af1c571bb0c37d1407430e33/lib/junos-ez/facts/version.rb#L46