### PR TITLE
Add proper MX platform support

### DIFF
--- a/lib/junos-ez/facts/personality.rb
+++ b/lib/junos-ez/facts/personality.rb
@@ -1,14 +1,14 @@
 Junos::Ez::Facts::Keeper.define( :personality ) do |ndev, facts|
-  
-  uses :chassis, :routingengines  
+
+  uses :chassis, :routingengines
   model = facts[:hardwaremodel]
 
   examine = ( model != "Virtual Chassis" ) ? model : facts.select {|k,v| k.match(/^RE[0..9]+/) }.values[0][:model]
-      
-  facts[:personality] = case examine   
+
+  facts[:personality] = case examine
   when /^(EX)|(QFX)|(PTX)|(OCX)/i
     :SWITCH
-  when /^MX/i
+  when /^(MX)|(JNP)/i
     :MX
   when /^vMX/i
     facts[:virtual] = true
@@ -21,5 +21,5 @@ Junos::Ez::Facts::Keeper.define( :personality ) do |ndev, facts|
   when /SRX(\d){4}/i
     :SRX_HIGHEND
   end
-  
+
 end


### PR DESCRIPTION
This library was failing with the following when attempting to run netconf operations against juniper MX devices:

`Junos::Ez::NoProviderError: target does not support vlan bridges
from /home/packet/narwhal/vendor/bundle/ruby/2.4.0/bundler/gems/ruby-junos-ez-stdlib-b318753782b7/lib/junos-ez/vlans.rb:22:in 'Provider'`

`facts[:personality]` needs to be set to determine `facts[:switch_style]`. `facts[:personality]` is set by matching the chassis hardware description on the Junos device:

```
mcanatella@fsr1.lab1> show chassis hardware                    
Hardware inventory:
Item             Version  Part number  Serial number     Description
Chassis                                BW707             JNP204 [MX204]
...
```